### PR TITLE
Project phase two

### DIFF
--- a/HUGO_MIGRATION_PLAN.md
+++ b/HUGO_MIGRATION_PLAN.md
@@ -141,10 +141,16 @@ Phase 1 outputs:
 
 ### Phase 2 - Initialize Hugo
 
-- [ ] Add Hugo config (`hugo.toml`) with site metadata from `gatsby-config.js`
-- [ ] Configure permalinks for blog posts to match existing URLs
-- [ ] Enable Goldmark and syntax highlighting defaults
-- [ ] Keep `static/robots.txt` and `static/_redirects`
+- [x] Add Hugo config (`hugo.toml`) with site metadata from `gatsby-config.js`
+- [x] Configure permalinks for blog posts to match existing URLs
+- [x] Enable Goldmark and syntax highlighting defaults
+- [x] Keep `static/robots.txt` and `static/_redirects`
+
+Phase 2 outputs:
+
+- `hugo.toml` with site metadata, blog permalink strategy, Goldmark, and syntax highlighting defaults
+- Verified blog URL parity (`160/160` post routes) against `migration/phase-1-route-inventory.json`
+- Added a temporary frontmatter date fallback (`:filename`, `:fileModTime`) to avoid mass-editing legacy date formats in parity phase
 
 ### Phase 3 - Blog templates
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,33 @@
+baseURL = "https://chancesmith.io/"
+languageCode = "en-us"
+title = "Chance Smith"
+ignoreFiles = ["^content/_drafts/", "^content/_ready/"]
+
+[params]
+  author = "Chance Smith"
+  description = "What if management wasn't about controlling the work, but creating space for it? Exploring leadership that serves engineers instead of managing them."
+
+  [params.social]
+    twitter = "chance_smith"
+    github = "chancesmith"
+
+[permalinks]
+  blog = "/:contentbasename/"
+
+[frontmatter]
+  date = [":filename", ":fileModTime"]
+  lastmod = [":git", ":fileModTime"]
+  publishDate = []
+  expiryDate = []
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
+  [markup.highlight]
+    codeFences = true
+    guessSyntax = true
+    lineNos = false
+    noClasses = false
+    style = "github"

--- a/migration/phase-2-validation.md
+++ b/migration/phase-2-validation.md
@@ -1,0 +1,32 @@
+# Phase 2 Validation (Hugo initialization)
+
+Date: 2026-02-15
+
+## Checks run
+
+1. Hugo config parses and content metadata loads:
+
+   - Command: `/home/ubuntu/go/bin/hugo list all --source /workspace`
+   - Result: success
+
+2. Blog URL parity against Phase 1 inventory:
+
+   - Command:
+     - `/home/ubuntu/go/bin/hugo list all --source /workspace > /tmp/hugo-list.csv`
+     - Compared section `blog` permalinks to `migration/phase-1-route-inventory.json` (`routes.posts`)
+   - Result: `expected=160 got=160 missing=0 extra=0`
+
+3. Hugo build starts successfully with current config:
+
+   - Command: `/home/ubuntu/go/bin/hugo --source /workspace --destination /tmp/hugo-public`
+   - Result: success (warnings expected until Phase 3 templates are added)
+
+4. Static files required by migration constraints are still present:
+
+   - `static/_redirects`
+   - `static/robots.txt`
+
+## Notes / known follow-up
+
+- Legacy content includes non-standard frontmatter date formats. To keep Phase 2 low-risk and avoid mass content churn, `hugo.toml` currently resolves page dates from `:filename` then `:fileModTime`.
+- Phase 3 should revisit post date display/sorting behavior so output matches Gatsby intent.


### PR DESCRIPTION
Initialize Hugo configuration for blog post URL parity and update migration documentation to complete Phase 2.

The `hugo.toml` includes a temporary date fallback (`:filename`, `:fileModTime`) to handle legacy frontmatter date formats without requiring mass content edits in this phase.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1eff7c74-67be-44b5-8856-e9c8d3353be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1eff7c74-67be-44b5-8856-e9c8d3353be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

